### PR TITLE
feat(vscode): :sparkles: add bracket autocomplete and indentation

### DIFF
--- a/clients/code/language-config.json
+++ b/clients/code/language-config.json
@@ -1,0 +1,67 @@
+{
+	"comments": {
+		"lineComment": "//",
+		"blockComment": [
+			"/*",
+			"*/"
+		]
+	},
+	"brackets": [
+		[
+			"{",
+			"}"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"(",
+			")"
+		]
+	],
+	"autoClosingPairs": [
+		{
+			"open": "{",
+			"close": "}"
+		},
+		{
+			"open": "[",
+			"close": "]"
+		},
+		{
+			"open": "(",
+			"close": ")"
+		},
+		{
+			"open": "/*",
+			"close": " */"
+		}
+	],
+	"surroundingPairs": [
+		[
+			"{",
+			"}"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"(",
+			")"
+		],
+		[
+			"\"",
+			"\""
+		],
+		[
+			"'",
+			"'"
+		]
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$",
+		"decreaseIndentPattern": "^\\s*(\\s*\\/[*].*[*]\\/\\s*)*[})]"
+	}
+}

--- a/clients/code/package.json
+++ b/clients/code/package.json
@@ -17,7 +17,6 @@
 		"vscode": "^1.52.0"
 	},
 	"activationEvents": [
-		"onLanguage:plaintext",
 		"onLanguage:spwn"
 	],
 	"main": "./client/out/extension",
@@ -52,6 +51,18 @@
 			}
 		}
 	},
+	"languages": [
+		{
+			"id": "spwn",
+			"extensions": [
+				".spwn"
+			],
+			"aliases": [
+				"SPWN"
+			],
+			"configuration": "language-config.json"
+		}
+	],
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -b",

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -9,6 +9,9 @@
 	],
 	"settings": {
 		"lldb.showDisassembly": "auto",
-		"lldb.dereferencePointers": true
+		"lldb.dereferencePointers": true,
+		"conventionalCommits.scopes": [
+			"vscode"
+		]
 	}
 }


### PR DESCRIPTION
it does what it says. It will auto-close (), [], {}, and /* */
This also has indentation rules (which are def not stolen from rust-analyzers thing)